### PR TITLE
feat(config): add --config flag with $HOME fallback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,22 +12,34 @@ static void signal_handler(int signum);
 
 std::shared_ptr<txr::Transmitter> _transmitter {nullptr};
 
-int main()
+int main(int argc, char** argv)
 {
 	signal(SIGINT, signal_handler);
 	signal(SIGTERM, signal_handler);
 	setbuf(stdout, NULL); // Disable stdout buffering
 
-	// Two-tier config lookup: user override > deb-installed default
+	// Config lookup: --config <path> (or --config=<path>) overrides everything;
+	// otherwise user override > deb-installed default.
 	const std::string home = getenv("HOME") ? getenv("HOME") : "/tmp";
 	const auto user_config = std::filesystem::path(home) / ".config/ark/rid-transmitter/config.toml";
 	const auto default_config = std::filesystem::path("/opt/ark/share/rid-transmitter/config.toml");
-	const auto config_path = std::filesystem::exists(user_config) ? user_config : default_config;
+	std::string config_path = (std::filesystem::exists(user_config) ? user_config : default_config).string();
+
+	for (int i = 1; i < argc; i++) {
+		std::string arg = argv[i];
+
+		if (arg == "--config" && i + 1 < argc) {
+			config_path = argv[++i];
+
+		} else if (arg.rfind("--config=", 0) == 0) {
+			config_path = arg.substr(std::string("--config=").size());
+		}
+	}
 
 	toml::table config;
 
 	try {
-		config = toml::parse_file(config_path.string());
+		config = toml::parse_file(config_path);
 
 	} catch (const toml::parse_error& err) {
 		std::cerr << "Parsing failed:\n" << err << "\n";


### PR DESCRIPTION
## Summary

Add a `--config <path>` (or `--config=<path>`) argument so the config file can be read from an explicit path, defaulting to the existing `$HOME/.local/share/rid-transmitter/config.toml`.

## Problem

The config path was hardcoded to `$HOME/.local/share/rid-transmitter/config.toml`. ARK-OS is moving to FHS packaging where the config lives at `/etc/ark-os/rid-transmitter.toml` and the service runs as a system user, so the binary, the web UI, and the shipped config must all reference the same file.

## Solution

Parse `--config`/`--config=` from argv and use it for the TOML load, keeping the `$HOME` path as the default so dev-machine behaviour is unchanged.

Part of ARK-Electronics/ARK-OS#68.
